### PR TITLE
Fix agent enrollment and incoming data checks

### DIFF
--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/confirm_agent_enrollment.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/confirm_agent_enrollment.tsx
@@ -5,31 +5,69 @@
  * 2.0.
  */
 
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { EuiCallOut, EuiButton, EuiText, EuiLink } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { i18n } from '@kbn/i18n';
 
-import { useGetAgentStatus } from '../../hooks';
+import { sendGetAgents } from '../../hooks';
 import { AGENTS_PREFIX } from '../../constants';
 interface Props {
   policyId?: string;
-  onClickViewAgents?: () => void;
   troubleshootLink: string;
+  onClickViewAgents?: () => void;
+  agentCount: number;
 }
+
+const POLLING_INTERVAL_MS = 5 * 1000; // 5 sec
+
+/**
+ * Hook for finding agents enrolled since component was rendered. Should be
+ * used by parent component to power rendering
+ * @param policyId
+ * @returns
+ */
+export const usePollingAgentCount = (policyId: string | undefined) => {
+  const [agentIds, setAgentIds] = useState([] as string[]);
+  // Use useRef to guarantee we get the same date on each render
+  const mountedAt = useRef(Date.now());
+
+  useEffect(() => {
+    let timeout: NodeJS.Timeout;
+
+    const poll = () => {
+      timeout = setTimeout(async () => {
+        const secSinceMounted = Math.ceil((Date.now() - mountedAt.current) / 1000);
+        const request = await sendGetAgents({
+          kuery: `${AGENTS_PREFIX}.policy_id:"${policyId}" and ${AGENTS_PREFIX}.enrolled_at >= "now-${secSinceMounted}s"`,
+          showInactive: false,
+        });
+
+        const newAgentIds = request.data?.items.map((i) => i.id) ?? agentIds;
+        if (newAgentIds.some((id) => !agentIds.includes(id))) {
+          setAgentIds(newAgentIds);
+        }
+
+        poll();
+      }, POLLING_INTERVAL_MS);
+    };
+
+    poll();
+    return () => {
+      clearTimeout(timeout);
+    };
+  }, [agentIds, policyId]);
+
+  return agentIds;
+};
 
 export const ConfirmAgentEnrollment: React.FunctionComponent<Props> = ({
   policyId,
-  onClickViewAgents,
   troubleshootLink,
+  onClickViewAgents,
+  agentCount,
 }) => {
-  // Check the agents enrolled in the last 10 minutes
-  const enrolledAt = 'now-10m';
-  const kuery = `${AGENTS_PREFIX}.enrolled_at >= "${enrolledAt}"`;
-  const agentStatusRequest = useGetAgentStatus({ kuery, policyId });
-  const agentsCount = agentStatusRequest.data?.results?.total;
-
-  if (!policyId || !agentsCount) {
+  if (!policyId || !agentCount) {
     return (
       <EuiText>
         <FormattedMessage
@@ -55,9 +93,9 @@ export const ConfirmAgentEnrollment: React.FunctionComponent<Props> = ({
       data-test-subj="ConfirmAgentEnrollmentCallOut"
       title={i18n.translate('xpack.fleet.agentEnrollment.confirmation.title', {
         defaultMessage:
-          '{agentsCount} {agentsCount, plural, one {agent has} other {agents have}} been enrolled.',
+          '{agentCount} {agentCount, plural, one {agent has} other {agents have}} been enrolled.',
         values: {
-          agentsCount,
+          agentCount,
         },
       })}
       color="success"

--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/managed_instructions.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/managed_instructions.tsx
@@ -40,6 +40,7 @@ import {
   IncomingDataConfirmationStep,
 } from './steps';
 import type { InstructionProps } from './types';
+import { usePollingAgentCount } from './confirm_agent_enrollment';
 
 const DefaultMissingRequirements = () => {
   const { getHref } = useLink();
@@ -88,6 +89,7 @@ export const ManagedInstructions = React.memo<InstructionProps>(
 
     const apiKey = useGetOneEnrollmentAPIKey(selectedApiKeyId);
     const fleetServerInstructions = useFleetServerInstructions(apiKey?.data?.item?.policy_id);
+    const enrolledAgentIds = usePollingAgentCount(selectedPolicy?.id);
 
     const { data: agents, isLoading: isLoadingAgents } = useGetAgents({
       page: 1,
@@ -161,12 +163,13 @@ export const ManagedInstructions = React.memo<InstructionProps>(
           selectedPolicyId: selectedPolicy?.id,
           onClickViewAgents,
           troubleshootLink: link,
+          agentCount: enrolledAgentIds.length,
         })
       );
       if (selectedPolicy) {
         baseSteps.push(
           IncomingDataConfirmationStep({
-            agentsIds: [selectedPolicy.id],
+            agentsIds: enrolledAgentIds,
           })
         );
       }
@@ -174,18 +177,18 @@ export const ManagedInstructions = React.memo<InstructionProps>(
     }, [
       selectedApiKeyId,
       setSelectedPolicyId,
+      settings?.fleet_server_hosts,
       selectedPolicy,
-      setSelectedAPIKeyId,
       agentPolicies,
       refreshAgentPolicies,
-      apiKey.data,
-      fleetServerSteps,
-      isFleetServerPolicySelected,
-      settings?.fleet_server_hosts,
       mode,
       setMode,
-      link,
+      isFleetServerPolicySelected,
       onClickViewAgents,
+      link,
+      fleetServerSteps,
+      apiKey?.data,
+      enrolledAgentIds,
     ]);
 
     if (fleetStatus.isReady && settings?.fleet_server_hosts.length === 0) {

--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/standalone_instructions.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/standalone_instructions.tsx
@@ -206,17 +206,6 @@ sudo rpm -vi elastic-agent-${kibanaVersion}-x86_64.rpm \nsudo systemctl enable e
         selectedPolicyId: agentPolicy?.id,
         downloadLink,
       }),
-      AgentEnrollmentConfirmationStep({
-        selectedPolicyId: agentPolicy?.id,
-        troubleshootLink: link,
-        onClickViewAgents,
-        agentCount: 0,
-      }),
-      agentPolicy
-        ? IncomingDataConfirmationStep({
-            agentsIds: [agentPolicy.id],
-          })
-        : undefined,
     ].filter(Boolean) as EuiContainedStepProps[];
 
     return (

--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/standalone_instructions.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/standalone_instructions.tsx
@@ -210,6 +210,7 @@ sudo rpm -vi elastic-agent-${kibanaVersion}-x86_64.rpm \nsudo systemctl enable e
         selectedPolicyId: agentPolicy?.id,
         troubleshootLink: link,
         onClickViewAgents,
+        agentCount: 0,
       }),
       agentPolicy
         ? IncomingDataConfirmationStep({

--- a/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/steps.tsx
+++ b/x-pack/plugins/fleet/public/components/agent_enrollment_flyout/steps.tsx
@@ -419,12 +419,14 @@ export const InstallStandaloneAgentStep = ({
 
 export const AgentEnrollmentConfirmationStep = ({
   selectedPolicyId,
-  onClickViewAgents,
   troubleshootLink,
+  onClickViewAgents,
+  agentCount,
 }: {
   selectedPolicyId?: string;
-  onClickViewAgents: () => void;
   troubleshootLink: string;
+  onClickViewAgents: () => void;
+  agentCount: number;
 }) => {
   return {
     title: i18n.translate('xpack.fleet.agentEnrollment.stepAgentEnrollmentConfirmation', {
@@ -433,8 +435,9 @@ export const AgentEnrollmentConfirmationStep = ({
     children: (
       <ConfirmAgentEnrollment
         policyId={selectedPolicyId}
-        onClickViewAgents={onClickViewAgents}
         troubleshootLink={troubleshootLink}
+        onClickViewAgents={onClickViewAgents}
+        agentCount={agentCount}
       />
     ),
   };


### PR DESCRIPTION
## Summary

This fixes the agent enrollment polling to only look for agents enrolled since the flyout was opened.

I also removed the enrollment and incoming data checks from the standalone instructions since those agents will not show up as enrolled in Fleet and we can't confirm incoming data for them. I asked for clarification on this here: https://github.com/elastic/kibana/issues/125534#issuecomment-1076672233

### Checklist

Delete any items that are not applicable to this PR.

- [ ] Any text added follows [EUI's writing guidelines](https://elastic.github.io/eui/#/guidelines/writing), uses sentence case text and includes [i18n support](https://github.com/elastic/kibana/blob/master/packages/kbn-i18n/README.md)
- [ ] [Documentation](https://www.elastic.co/guide/en/kibana/master/development-documentation.html) was added for features that require explanation or tutorials
- [ ] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios
- [ ] Any UI touched in this PR is usable by keyboard only (learn more about [keyboard accessibility](https://webaim.org/techniques/keyboard/))
- [ ] Any UI touched in this PR does not create any new axe failures (run axe in browser: [FF](https://addons.mozilla.org/en-US/firefox/addon/axe-devtools/), [Chrome](https://chrome.google.com/webstore/detail/axe-web-accessibility-tes/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US))
- [ ] If a plugin configuration key changed, check if it needs to be allowlisted in the cloud and added to the [docker list](https://github.com/elastic/kibana/blob/master/src/dev/build/tasks/os_packages/docker_generator/resources/base/bin/kibana-docker)
- [ ] This renders correctly on smaller devices using a responsive layout. (You can test this [in your browser](https://www.browserstack.com/guide/responsive-testing-on-local-server))
- [ ] This was checked for [cross-browser compatibility](https://www.elastic.co/support/matrix#matrix_browsers)


### Risk Matrix

Delete this section if it is not applicable to this PR.

Before closing this PR, invite QA, stakeholders, and other developers to identify risks that should be tested prior to the change/feature release.

When forming the risk matrix, consider some of the following examples and how they may potentially impact the change:

| Risk                      | Probability | Severity | Mitigation/Notes        |
|---------------------------|-------------|----------|-------------------------|
| Multiple Spaces&mdash;unexpected behavior in non-default Kibana Space. | Low | High | Integration tests will verify that all features are still supported in non-default Kibana Space and when user switches between spaces. |
| Multiple nodes&mdash;Elasticsearch polling might have race conditions when multiple Kibana nodes are polling for the same tasks. | High | Low | Tasks are idempotent, so executing them multiple times will not result in logical error, but will degrade performance. To test for this case we add plenty of unit tests around this logic and document manual testing procedure. |
| Code should gracefully handle cases when feature X or plugin Y are disabled. | Medium | High | Unit tests will verify that any feature flag or plugin combination still results in our service operational. |
| [See more potential risk examples](https://github.com/elastic/kibana/blob/master/RISK_MATRIX.mdx) |


### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
